### PR TITLE
chore: replaced deprecated serve method with Deno.serve

### DIFF
--- a/supabase/functions/resend/index.ts
+++ b/supabase/functions/resend/index.ts
@@ -1,5 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 
 const handler = async (_request: Request): Promise<Response> => {
@@ -27,4 +25,5 @@ const handler = async (_request: Request): Promise<Response> => {
   });
 };
 
-serve(handler);
+// Serves with the port 8000 on hostname "127.0.0.1".
+Deno.serve(handler)

--- a/supabase/functions/resend/index.ts
+++ b/supabase/functions/resend/index.ts
@@ -25,5 +25,4 @@ const handler = async (_request: Request): Promise<Response> => {
   });
 };
 
-// Serves with the port 8000 on hostname "127.0.0.1".
 Deno.serve(handler)


### PR DESCRIPTION
This pull request addresses #4 

In theory this should work fine as a straight swap however there are no tests in place to check the functionality is exactly the same and I do not have the necessary dependencies installed to test it manually.

A manual review of the pull request wouldn't go a miss just to be safe.